### PR TITLE
Remove Jameson support from extension manifest

### DIFF
--- a/doc/INTEGRATION.md
+++ b/doc/INTEGRATION.md
@@ -1,0 +1,15 @@
+# Integrating Sparkle with your Snap! fork
+Starting with v0.4, people who maintain Snap! forks can now add the Sparkle addon system without requiring the use of browser extensions; this page is a brief guide on how to set it up!
+
+## Preparing for integration
+Before trying to integrate Sparkle into your mod, ensure that its URLs are not currently listed in [the extension manifest for Sparkle](manifest.json).
+
+If it is, please open a PR to remove the URLs and wait for the next release of Sparkle before integrating it into your fork.
+
+## Adding the necessary source code files
+Visit the Releases tab and choose a Sparkle version. Download the file named `sparkle.js`, and add it to the `src/` directory of your fork.
+
+## Modifying snap.html
+In order to make Sparkle automatically load as a component of your fork, open the `snap.html` file, create a new line after the last `<script>...</script>` tag, and paste in the following code: `<script>script src="src/sparkle.js"></script>`.
+
+Congratulations! You've integrated your fork with Sparkle!

--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,6 @@
         "*://snap.berkeley.edu/snap/dev/snap.html",
         "*://e016.github.io/split-mod/split.html",
         "*://codingisfun2831t.github.io/split-mod-prs/split.html",
-        "*://mojavesoft.net/ide/snap",
-        "*://mojavesoft.org/ide/snap",
         "*://alessandrito123.github.io/Snavanced/snap.html"
       ],
       "js": ["reload.js", "index.js"],

--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/sh
 # Compress all of the files required for a working Sparkle installation into a file named sparkle.zip.
+mkdir dist/
+cd dist/
 rm -f sparkle.zip
-zip -9 sparkle.zip icons/* LICENSE index.js manifest.json reload.js
+zip -9 sparkle.zip ../icons/* ../LICENSE ../index.js ../manifest.json
+cp ../index.js sparkle.js


### PR DESCRIPTION
I'm currently working on a new feature for Jameson where it provides its own version of Sparkle, so users don't need to install a browser extension in order to use addons.

This PR introduces the necessary changes to make this work. The built-in Sparkle integration for Jameson won't be enabled until v0.4 comes out.