### PR TITLE
Fix mysterious JSON issues on Firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -1589,7 +1589,7 @@ function preloadAddonFromPath(path) {
                 let data = window.__crackle__.storage.get("crackle_autoload_mods");
                 if (!data || data == "[]")
                     (window.__crackle__.storage.set("crackle_autoload_mods", "{}"),
-                        (data = {}));
+                        (data = "{}"));
 
                 return JSON.parse(data) || {};
             },


### PR DESCRIPTION
On [line 1592](https://github.com/Mojavesoft-Group/sparkle/blob/18ebefb9abafd98f5db7b25f9e6ca90dbdc45c9f/index.js#L1592) the `data` variable should be a string and not an object. This should fix #36.

@e016 @Bubgamer07 Would you please test this patch? It works on my machine, Firefox 150.0.2 on Ubuntu 26.04.