### PR TITLE
Fix preloadAddonFromPath behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -1262,7 +1262,6 @@ function waitForSnapReady() {
 }
 
 function preloadAddonFromPath(path) {
-    return () => {
         fetch(path).then((x) =>
         {
             if (!x.ok) {
@@ -1272,7 +1271,6 @@ function preloadAddonFromPath(path) {
         }).then((code) => {
             window.__crackle__.preloadMod(code);
         })
-    }
 }
 
 (async function() {


### PR DESCRIPTION
As described in #43, I made a mistake in my definition of how preloaded addons should work in #23 and accidentally specified that `preloadAddonFromPath` should be a higher-order function (HOF).

This PR modifies `preloadAddonFromPath` to behave in the way that I actually intended for it to.