### PR TITLE
Add this.api.sparkle API to ease the transition to a Sparkle class

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -43,6 +43,7 @@ This section describes the variables/functions that can be invoked from `this.ap
 
 - `ide` - The `IDE_Morph` (check Snap!'s `gui.js` for more infomation) Snap! is using. This is the Snap! interface.
 - `world` - The `WorldMorph` object from Snap!.
+- `sparkle` - Sparkle's internal state; handle with care.
 
 ### Functions
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function commaOr(...items) {
 // API for mods
 class API {
     constructor(mod) {
+        this.sparkle = window.__crackle__;
         this.mod = mod;
         this.world = world;
         this.ide = world.children[0];


### PR DESCRIPTION
This PR adds the `this.api.sparkle` API for addons, allowing them to access Sparkle's internal state without relying on the `window.__crackle__` variable, which is going to be removed by #38.