### PR TITLE
Remove this.api.sparkle

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -43,7 +43,7 @@ This section describes the variables/functions that can be invoked from `this.ap
 
 - `ide` - The `IDE_Morph` (check Snap!'s `gui.js` for more infomation) Snap! is using. This is the Snap! interface.
 - `world` - The `WorldMorph` object from Snap!.
-- `sparkle` - Sparkle's internal state; handle with care.
+- `crackle` - Sparkle's internal state; handle with care. The data contained within this variable is subject to change at any point.
 
 ### Functions
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ function commaOr(...items) {
 // API for mods
 class API {
     constructor(mod) {
-        this.sparkle = window.__crackle__;
         this.mod = mod;
         this.world = world;
         this.ide = world.children[0];


### PR DESCRIPTION
I just realized that we already have an older API for this, `this.api.crackle`, which was apparently added in commit 48f63ed but not documented anywhere.