### PR TITLE
pendingActions API

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -58,6 +58,7 @@ This section describes the variables/functions that can be invoked from `this.ap
 - `storage` - An object with procedures for storing data, local for each mod:
   - `get` - Gets a property, second parameter is a default value if the property is non-existent
   - `set` - Sets a property
+- `requestPendingAction` - Informs Sparkle that a task (specified as a string in the first argument) should be performed when all addons are done loading. (Possible values are `"refreshIDE"` and `"refreshLogo"`.)
 
 ### Removed APIs
 Support for these APIs is no longer included in Sparkle.

--- a/index.js
+++ b/index.js
@@ -179,6 +179,11 @@ class API {
             throw new Error("snap not compatible");
         }
     }
+
+    requestPendingAction(action) {
+        Mod.pendingActions.add(action);
+        return Mod.pendingActions;
+    }
 }
 
 // A Mod, loaded from code
@@ -190,7 +195,7 @@ class Mod extends EventTarget {
     static AUTHOR = "John Doe";
     static DEPENDS = [];
     static DO_MENU = false;
-    static pendingActions = [];
+    static pendingActions = new Set();
     constructor() {
         super(); // initialize EventTarget
 
@@ -230,7 +235,7 @@ class Mod extends EventTarget {
 
     executeAddon(autoloaded) {
         this.main();
-        if (!autoloaded) {performAllPendingActions();}
+        if (!autoloaded) {Mod.performAllPendingActions();}
     }
 
     static findModById(id) {
@@ -251,11 +256,11 @@ class Mod extends EventTarget {
     }
 
     static performAllPendingActions() {
-        if (Mod.pendingActions.includes("refreshIDE")) {
+        if (Mod.pendingActions.has("refreshIDE")) {
             console.log("Refreshing IDE...");
             new this().api.ide.refreshIDE();
         }
-        this.pendingActions = [];
+        this.pendingActions.clear();
     }
 }
 
@@ -1477,7 +1482,7 @@ function preloadAddonFromPath(path) {
 
     // create the __crackle__ object
     window.__crackle__ = {
-        version: "0.8.0",
+        version: "0.9.0",
         source: "https://github.com/Mojavesoft-Group/sparkle/releases",
         loadedMods: [],
         extraApi: {},

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function commaOr(...items) {
 // API for mods
 class API {
     constructor(mod) {
+        this.sparkle = window.__crackle__;
         this.mod = mod;
         this.world = world;
         this.ide = world.children[0];
@@ -189,7 +190,7 @@ class Mod extends EventTarget {
     static AUTHOR = "John Doe";
     static DEPENDS = [];
     static DO_MENU = false;
-
+    static pendingActions = [];
     constructor() {
         super(); // initialize EventTarget
 
@@ -227,6 +228,11 @@ class Mod extends EventTarget {
         }
     }
 
+    executeAddon(autoloaded) {
+        this.main();
+        if (!autoloaded) {performAllPendingActions();}
+    }
+
     static findModById(id) {
         return window.__crackle__.loadedMods.find((mod) => mod.ID == id);
     }
@@ -242,6 +248,14 @@ class Mod extends EventTarget {
         );
 
         return ret;
+    }
+
+    static performAllPendingActions() {
+        if (Mod.pendingActions.includes("refreshIDE")) {
+            console.log("Refreshing IDE...");
+            new this().api.ide.refreshIDE();
+        }
+        this.pendingActions = [];
     }
 }
 
@@ -1507,7 +1521,7 @@ function preloadAddonFromPath(path) {
         })(),
 
         // load a mod from code, TEMPORARY. use addMod for loading normal mods from the menu or download.
-        loadMod(code) {
+        loadMod(code, autoloaded) {
             let mod = new(Function(code)())();
 
             if (this.loadedMods.some((element) => element.ID == mod.ID)) {
@@ -1522,7 +1536,7 @@ function preloadAddonFromPath(path) {
             try {
                 mod.setupOptions();
                 if (!this.disabledMods[mod.ID]) {
-                    mod.main();
+                    mod.executeAddon(autoloaded);
                 }
             } catch (e) {
                 ide.showMessage(
@@ -1596,7 +1610,7 @@ function preloadAddonFromPath(path) {
             this.disabledMods[id] = false;
             this.saveDisabled();
             if (mod.DO_MENU) mod.menu = new MenuMorph();
-            mod.main();
+            mod.executeAddon(false);
         },
         disableMod(id) {
             const mod = Mod.findModById(id);
@@ -1651,6 +1665,7 @@ function preloadAddonFromPath(path) {
                     try {
                         // TODO: optional fetching of mods
                         window.__crackle__.loadMod(mod, true);
+                        Mod.performAllPendingActions();
                     } catch (e) {
                         ide.showMessage(
                             "Failed to autoload addon, check console for more info",

--- a/index.js
+++ b/index.js
@@ -256,10 +256,18 @@ class Mod extends EventTarget {
     }
 
     static performAllPendingActions() {
+        let tempAPI = new API();
         if (Mod.pendingActions.has("refreshIDE")) {
             console.log("Refreshing IDE...");
-            new this().api.ide.refreshIDE();
+            tempAPI.ide.refreshIDE();
         }
+
+        if (Mod.pendingActions.has("refreshLogo")) {
+            console.log("Refreshing logo...");
+            tempAPI.ide.buildPanes();
+            tempAPI.ide.fixLayout();
+        }
+
         this.pendingActions.clear();
     }
 }


### PR DESCRIPTION
This PR introduces the `pendingActions` API for letting addons tell Sparkle to do specific low-priority tasks that could slow down Snap! if done improperly, such as refreshing the IDE. Closes #53.