### PR TITLE
Add CONTRIBUTORS field

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -14,6 +14,7 @@ return class extends Mod {
   DESCRIPTION = "An example addon for Sparkle."; // description
   VERSION = "1.0"; // version
   AUTHOR = "Your Name"; // author
+  CONTRIBUTORS = "N/A"; // non-author contributors to addon (only displayed in Sparkle >=v0.10.0)
   DEPENDS = []; // dependencies (addon ids, useful for libraries)
   DO_MENU = true; // whether to add a menu item
   // format for options dialog

--- a/index.js
+++ b/index.js
@@ -198,9 +198,11 @@ class Mod extends EventTarget {
     static pendingActions = new Set();
     constructor() {
         super(); // initialize EventTarget
-
         this.api = new API(this);
         this.menuHooks = [];
+        if (!this.CONTRIBUTORS) {
+            this.CONTRIBUTORS = "N/A"
+        }
     }
 
     setupOptions() {
@@ -533,6 +535,7 @@ class CrackleMorph extends ScrollFrameMorph {
                         `ID: ${mod.ID}\n` +
                         `Description: ${mod.DESCRIPTION}\n` +
                         `Version: ${mod.VERSION}\n` +
+                        `Contributors: ${mod.CONTRIBUTORS}\n` +
                         `Author: ${mod.AUTHOR}`,
                         world,
                     );


### PR DESCRIPTION
The `CONTRIBUTORS` field for addons is intended for people who have contributed to an addon but aren't the primary author.