### PR TITLE
add multiselect option type and allow mods to open their own settings

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -60,6 +60,7 @@ This section describes the variables/functions that can be invoked from `this.ap
   - `get` - Gets a property, second parameter is a default value if the property is non-existent
   - `set` - Sets a property
 - `requestPendingAction` - Informs Sparkle that a task (specified as a string in the first argument) should be performed when all addons are done loading. (Possible values are `"refreshIDE"` and `"refreshLogo"`.)
+- `openSettings` - Open this mods settings menu.
 
 ### Removed APIs
 Support for these APIs is no longer included in Sparkle.
@@ -133,6 +134,19 @@ Addons with an `OPTIONS_FORMAT` array will have an "Options" button in the addon
     minLength: 1,
     maxLength: 5,
   },
+  {
+    id: "validHellos",
+    name: "Select all hellos that apply",
+    type: "multiSelect",
+    options: {
+      "Hi": "hi",
+      "Hello": "hello",
+      "Sick": "sick",
+      "Howdy": "howdy",
+    },
+    // what options should toggled by default
+    default: ["hi", "hello", "sick", "howdy"],
+  }
 ];
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -134,19 +134,12 @@ Addons with an `OPTIONS_FORMAT` array will have an "Options" button in the addon
     minLength: 1,
     maxLength: 5,
   },
-  {
-    id: "validHellos",
-    name: "Select all hellos that apply",
-    type: "multiSelect",
-    options: {
-      "Hi": "hi",
-      "Hello": "hello",
-      "Sick": "sick",
-      "Howdy": "howdy",
-    },
-    // what options should toggled by default
-    default: ["hi", "hello", "sick", "howdy"],
-  }
+  default: {
+      "hi": true,
+      "hello": true,
+      "sick": false,
+      "howdy": false,
+  },
 ];
 ```
 

--- a/example.js
+++ b/example.js
@@ -78,8 +78,12 @@ return class extends Mod {
                 "Sick": "sick",
                 "Howdy": "howdy",
             },
-            // what options should toggled by default
-            default: ["hi", "hello", "sick", "howdy"],
+            default: {
+                "hi": true,
+                "hello": true,
+                "sick": false,
+                "howdy": false,
+            },
         }
     ]; // format for options
 
@@ -103,7 +107,7 @@ return class extends Mod {
             new DialogBoxMorph(
                 myself,
                 (choice) => {
-                    let valid = myself.options.validHellos.includes(choice);
+                    let valid = myself.options.validHellos[choice];
 
                     new DialogBoxMorph().inform(
                         "Result",

--- a/example.js
+++ b/example.js
@@ -68,12 +68,26 @@ return class extends Mod {
             minLength: 1,
             maxLength: 5,
         },
+        {
+            id: "validHellos",
+            name: "Select all hellos that apply",
+            type: "multiSelect",
+            options: {
+                "Hi": "hi",
+                "Hello": "hello",
+                "Sick": "sick",
+                "Howdy": "howdy",
+            },
+            // what options should toggled by default
+            default: ["hi", "hello", "sick", "howdy"],
+        }
     ]; // format for options
 
     // Main function - gets ran when the mod is loaded
     main() {
         // allow access to the API in the menu functions and such, shortcut
         let api = this.api;
+        let myself = this;
 
         // Example adding a menu item - see morphic.js's MenuMorph
         // for more info on menus
@@ -84,6 +98,35 @@ return class extends Mod {
 
             );
         });
+
+        this.menu.addItem("Check hello", () => {
+            new DialogBoxMorph(
+                myself,
+                (choice) => {
+                    let valid = myself.options.validHellos.includes(choice);
+
+                    new DialogBoxMorph().inform(
+                        "Result",
+                        valid ? "Yeah. That's good." : "Yeah, no. Get out of here.",
+                        api.world
+                    );
+                }
+            ).prompt(
+                "Check a hello",
+                "hello",
+                api.world,
+                null,
+                {
+                    "Hi": "hi",
+                    "Hello": "hello",
+                    "Sick": "sick",
+                    "Howdy": "howdy",
+                }
+            );
+        })
+
+        this.menu.addLine();
+        this.menu.addItem("Settings", () => { api.openSettings() })
 
         // Example of using events
         this.addEventListener("categoryCreating", (e) => {

--- a/index.js
+++ b/index.js
@@ -185,6 +185,10 @@ class API {
         Mod.pendingActions.add(action);
         return Mod.pendingActions;
     }
+
+    openSettings() {
+        this.sparkle.showModOptions(this.mod);
+    }
 }
 
 // A Mod, loaded from code
@@ -849,7 +853,42 @@ class CrackleMorph extends ScrollFrameMorph {
         this.settings = new AlignmentMorph("column", 5);
         this.settings.alignment = "left";
         this.mod.OPTIONS_FORMAT.forEach((format) => {
-            if (format?.id && Array.isArray(format.default)) {
+            if (format?.type == "multiSelect") {
+                const myself = this;
+                let label = new StringMorph(
+                        format.name,
+                        12,
+                        "sans-serif",
+                        true,
+                        null,
+                        false,
+                        false,
+                        null,
+                        BLACK,
+                    );
+
+                this.settings.add(label);
+
+                for (const [display, real] of Object.entries(format.options)) {
+                    let checkbox = new ToggleMorph(
+                        "checkbox",
+                        null,
+                        () => {
+                            let current = myself.newOptions[format.id].includes(real);
+
+                            if (current) {
+                                myself.newOptions[format.id] = myself.newOptions[format.id].filter(item => item !== real);
+                            } else {
+                                myself.newOptions[format.id].push(real);
+                            }
+                        }, // action,
+                        display, // label
+                        () => myself.newOptions[format.id].includes(real), // query
+                    );
+
+                    this.settings.add(checkbox);
+                }
+            } else if (format?.id && Array.isArray(format.default)) {
                 const myself = this;
                 let list,
                     label = new StringMorph(
@@ -960,7 +999,7 @@ class CrackleMorph extends ScrollFrameMorph {
                 total.add(morph);
                 total.fixLayout();
                 this.settings.add(total);
-            } else if (typeof format === "string") {
+            } else if (typeof format === "string") { // header
                 let morph = new StringMorph(
                     format,
                     15,
@@ -973,7 +1012,7 @@ class CrackleMorph extends ScrollFrameMorph {
                     BLACK,
                 );
                 this.settings.add(morph);
-            } else if (format === null) {
+            } else if (format === null) { // spacer
                 let morph = new Morph();
                 morph.alpha = 0;
                 morph.setExtent(new Point(200, 5));

--- a/index.js
+++ b/index.js
@@ -874,16 +874,10 @@ class CrackleMorph extends ScrollFrameMorph {
                         "checkbox",
                         null,
                         () => {
-                            let current = myself.newOptions[format.id].includes(real);
-
-                            if (current) {
-                                myself.newOptions[format.id] = myself.newOptions[format.id].filter(item => item !== real);
-                            } else {
-                                myself.newOptions[format.id].push(real);
-                            }
+                            myself.newOptions[format.id][real] = !myself.newOptions[format.id][real];
                         }, // action,
                         display, // label
-                        () => myself.newOptions[format.id].includes(real), // query
+                        () => myself.newOptions[format.id][real], // query
                     );
 
                     this.settings.add(checkbox);


### PR DESCRIPTION
Self explantory. Multiselect options follow a format like this:
```javascript
{
    id: "validHellos",
    name: "Select all hellos that apply",
    type: "multiSelect",
    options: {
        "Hi": "hi",
        "Hello": "hello",
        "Sick": "sick",
        "Howdy": "howdy",
    },
    // what options should toggled by default
    default: ["hi", "hello", "sick", "howdy"],
}
```
Options is a dictionary similar to a dropdown menu, and default is just the values that should e enabled. It looks like this:
<img width="155" height="103" alt="image" src="https://github.com/user-attachments/assets/f4bb03b8-e3bf-421b-a498-bfa4ea024272" />


And for the second part, a mod can open their own settings by calling `this.api.openSettings()`. I have added documentation for that function, and example.js has a menu option for it.