### PR TITLE
Remove Sparkle settings & developer mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -715,6 +715,7 @@ class CrackleMorph extends ScrollFrameMorph {
         );
         this.contents.fixLayout();
     }
+    /*
     buildSettings() {
         if (this.settings) {
             this.settings.destroy();
@@ -737,6 +738,7 @@ class CrackleMorph extends ScrollFrameMorph {
         }
         this.addContents(this.settings);
     }
+    */
     buildOptionMorph(format, getter, setter) {
         let morph;
         if (format.type === "boolean") {
@@ -1580,7 +1582,7 @@ function preloadAddonFromPath(path) {
     };
     Object.assign(window.__crackle__, {
         version: API.versionStringFromSemver(window.__crackle__.versionArray),
-        source: "https://github.com/sparkle-devs/sparkle/releases",
+        source: "https://github.com/Mojavesoft-Group/sparkle/releases",
         loadedMods: [],
         extraApi: {},
         disabledMods: {},
@@ -1589,7 +1591,7 @@ function preloadAddonFromPath(path) {
         allEventTargets: {},
         crackleSymbol: Symbol("Crackle Data"),
         wrappedFunctions: new Map(),
-        addonRepoPath: "https://raw.githubusercontent.com/sparkle-devs/SparkleAddons/refs/heads/master/",
+        addonRepoPath: "https://raw.githubusercontent.com/Mojavesoft-Group/SparkleMods/refs/heads/master/",
         snap: (function() {
             // Other forks?
             if (window.snapForkName && window.snapForkVersion) {
@@ -1787,10 +1789,12 @@ function preloadAddonFromPath(path) {
             },
         },
         isDev: false,
+        /*
         toggleDev() {
             window.__crackle__.isDev = !window.__crackle__.isDev;
             this.saveSettings();
         },
+        */
         loadSettings() {
             const settings = JSON.parse(this.storage.get("crackle_settings") || "{}");
             this.isDev = settings.isDev !== false;
@@ -1892,6 +1896,7 @@ function preloadAddonFromPath(path) {
                     world,
                 );
             },
+            /*
             settings() {
                 const dlg = new DialogBoxMorph(),
                     body = new CrackleMorph(window.__crackle__, false);
@@ -1905,6 +1910,7 @@ function preloadAddonFromPath(path) {
                 dlg.fixLayout();
                 dlg.popUp(world);
             },
+            */
             download() {
                 window.open(window.__crackle__.source, "_blank");
             },
@@ -1992,7 +1998,7 @@ function preloadAddonFromPath(path) {
                     new Color(255, 100, 100) :
                     new Color(100, 0, 0);
                 if (IDE_Morph.prototype.ideRender) {
-                    menu.bgColor = controlBar.color;
+                    menu.bgColor = IDE_Morph.prototype.getControlBarColor();
                     IDE_Morph.prototype.ideRender(menu);
                 }
                 menu.addItem("About Sparkle...", "about");

--- a/index.js
+++ b/index.js
@@ -2002,7 +2002,7 @@ function preloadAddonFromPath(path) {
                     IDE_Morph.prototype.ideRender(menu);
                 }
                 menu.addItem("About Sparkle...", "about");
-                menu.addItem("Sparkle settings...", "settings");
+                //menu.addItem("Sparkle settings...", "settings");
                 menu.addItem("Download source...", "download");
                 menu.addLine();
                 menu.addItem(

--- a/index.js
+++ b/index.js
@@ -1582,7 +1582,7 @@ function preloadAddonFromPath(path) {
     };
     Object.assign(window.__crackle__, {
         version: API.versionStringFromSemver(window.__crackle__.versionArray),
-        source: "https://github.com/Mojavesoft-Group/sparkle/releases",
+        source: "https://github.com/sparkle-devs/sparkle/releases",
         loadedMods: [],
         extraApi: {},
         disabledMods: {},
@@ -1591,7 +1591,7 @@ function preloadAddonFromPath(path) {
         allEventTargets: {},
         crackleSymbol: Symbol("Crackle Data"),
         wrappedFunctions: new Map(),
-        addonRepoPath: "https://raw.githubusercontent.com/Mojavesoft-Group/SparkleMods/refs/heads/master/",
+        addonRepoPath: "https://raw.githubusercontent.com/sparkle-devs/SparkleAddons/refs/heads/master/",
         snap: (function() {
             // Other forks?
             if (window.snapForkName && window.snapForkVersion) {

--- a/index.js
+++ b/index.js
@@ -1998,7 +1998,7 @@ function preloadAddonFromPath(path) {
                     new Color(255, 100, 100) :
                     new Color(100, 0, 0);
                 if (IDE_Morph.prototype.ideRender) {
-                    menu.bgColor = IDE_Morph.prototype.getControlBarColor();
+                    menu.bgColor = controlBar.color;
                     IDE_Morph.prototype.ideRender(menu);
                 }
                 menu.addItem("About Sparkle...", "about");

--- a/index.js
+++ b/index.js
@@ -715,7 +715,6 @@ class CrackleMorph extends ScrollFrameMorph {
         );
         this.contents.fixLayout();
     }
-    /*
     buildSettings() {
         if (this.settings) {
             this.settings.destroy();
@@ -738,7 +737,6 @@ class CrackleMorph extends ScrollFrameMorph {
         }
         this.addContents(this.settings);
     }
-    */
     buildOptionMorph(format, getter, setter) {
         let morph;
         if (format.type === "boolean") {
@@ -1789,12 +1787,10 @@ function preloadAddonFromPath(path) {
             },
         },
         isDev: false,
-        /*
         toggleDev() {
             window.__crackle__.isDev = !window.__crackle__.isDev;
             this.saveSettings();
         },
-        */
         loadSettings() {
             const settings = JSON.parse(this.storage.get("crackle_settings") || "{}");
             this.isDev = settings.isDev !== false;
@@ -1896,7 +1892,6 @@ function preloadAddonFromPath(path) {
                     world,
                 );
             },
-            /*
             settings() {
                 const dlg = new DialogBoxMorph(),
                     body = new CrackleMorph(window.__crackle__, false);
@@ -1910,7 +1905,6 @@ function preloadAddonFromPath(path) {
                 dlg.fixLayout();
                 dlg.popUp(world);
             },
-            */
             download() {
                 window.open(window.__crackle__.source, "_blank");
             },
@@ -2002,7 +1996,7 @@ function preloadAddonFromPath(path) {
                     IDE_Morph.prototype.ideRender(menu);
                 }
                 menu.addItem("About Sparkle...", "about");
-                //menu.addItem("Sparkle settings...", "settings");
+                menu.addItem("Sparkle settings...", "settings");
                 menu.addItem("Download source...", "download");
                 menu.addLine();
                 menu.addItem(

--- a/index.js
+++ b/index.js
@@ -715,6 +715,7 @@ class CrackleMorph extends ScrollFrameMorph {
         );
         this.contents.fixLayout();
     }
+    /*
     buildSettings() {
         if (this.settings) {
             this.settings.destroy();
@@ -737,6 +738,7 @@ class CrackleMorph extends ScrollFrameMorph {
         }
         this.addContents(this.settings);
     }
+    */
     buildOptionMorph(format, getter, setter) {
         let morph;
         if (format.type === "boolean") {
@@ -1786,15 +1788,18 @@ function preloadAddonFromPath(path) {
                 Mod.performAllPendingActions();
             },
         },
-        isDev: false,
+        isDev: true,
+        /*
         toggleDev() {
             window.__crackle__.isDev = !window.__crackle__.isDev;
             this.saveSettings();
         },
+
         loadSettings() {
             const settings = JSON.parse(this.storage.get("crackle_settings") || "{}");
             this.isDev = settings.isDev !== false;
         },
+
         saveSettings() {
             this.storage.set(
                 "crackle_settings",
@@ -1803,6 +1808,7 @@ function preloadAddonFromPath(path) {
                 }),
             );
         },
+        */
 
         showModOptions(mod) {
             const dlg = new ResizableDialogBoxMorph(),
@@ -1845,7 +1851,7 @@ function preloadAddonFromPath(path) {
 
         currentMenu: null,
     });
-    window.__crackle__.loadSettings();
+    //window.__crackle__.loadSettings();
 
     // adjust the project label position to be after the mod button
     // this is needed because the fixLayout for the IDE doesn't know
@@ -1892,6 +1898,7 @@ function preloadAddonFromPath(path) {
                     world,
                 );
             },
+            /*
             settings() {
                 const dlg = new DialogBoxMorph(),
                     body = new CrackleMorph(window.__crackle__, false);
@@ -1905,6 +1912,7 @@ function preloadAddonFromPath(path) {
                 dlg.fixLayout();
                 dlg.popUp(world);
             },
+            */
             download() {
                 window.open(window.__crackle__.source, "_blank");
             },
@@ -1996,7 +2004,7 @@ function preloadAddonFromPath(path) {
                     IDE_Morph.prototype.ideRender(menu);
                 }
                 menu.addItem("About Sparkle...", "about");
-                menu.addItem("Sparkle settings...", "settings");
+                //menu.addItem("Sparkle settings...", "settings");
                 menu.addItem("Download source...", "download");
                 menu.addLine();
                 menu.addItem(


### PR DESCRIPTION
This PR comments out Sparkle's settings menu as well as the code for toggling developer mode, because nobody actually uses this feature.

@codingisfun2831t What do you think?

Edit: This PR should not be merged until v0.10.2 comes out.