### PR TITLE
Improve GitHub Actions security

### DIFF
--- a/.github/workflows/auto-packager.yml
+++ b/.github/workflows/auto-packager.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: 'Obtain repository'
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 'Install Node'
         uses: actions/setup-node@v6

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+          persist-credentials: false
     - run: sudo apt install python3-tomli python3-tomli-w && python3 sparkle-bump-version.py
     
     - name: Commit changes

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+          persist-credentials: false
     - name: Format JavaScript code
       uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
Apparently, the checkout action likes to expose GitHub tokens by default, so this PR tells it not to.